### PR TITLE
Make lpname an optional argument with a default

### DIFF
--- a/bin/snap-open-lp
+++ b/bin/snap-open-lp
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-xdg-open https://code.launchpad.net/~ubuntu-desktop/+snap/$1
+xdg-open https://code.launchpad.net/~desktop-snappers/+snap/$1

--- a/bin/snap-rebuild
+++ b/bin/snap-rebuild
@@ -3,9 +3,17 @@
 arches="amd64 armhf arm64 i386"
 snap=$1
 
+if [ -z "$2" ]
+  then
+    lpname=desktop-snappers
+  else
+    lpname=$2
+fi
+
+
 for arch in $arches;
 do
-  lp-build-snap --lpname ubuntu-desktop \
+  lp-build-snap --lpname $lpname \
 	  --arch $arch --series bionic \
 	  --core-channel stable \
 	  --snapcraft-channel candidate $snap


### PR DESCRIPTION
Here are three examples I tested:

1. If the project is part of desktop-snappers, then no need to give the argument (because it's the default)
`snap-rebuild gnome-recipes`

2. ... But you can give desktop-snappers as an argument if you really want to:
`snap-rebuild gnome-calculator desktop-snappers`

3. You can give a different user as an argument
`snap-rebuild cherrytree hellsworth`